### PR TITLE
Use service worker to pre-cache app

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,8 @@ if (storageAvailable("localStorage")) {
   app.ports.restoredStateCache.send({ localStorage: "not_available" });
 }
 
-// If you want your app to work offline and load faster, you can change
-// unregister() to register() below. Note this comes with some pitfalls.
-// Learn more about service workers: https://bit.ly/CRA-PWA
-serviceWorker.unregister();
+serviceWorker.register({
+  onUpdate: () => {
+    app.ports.restoredStateCache.send({ serviceWorker: "update_available" });
+  }
+});


### PR DESCRIPTION
- Displays notification about update when service worker update is
  detected
- Accepting notified upgrade refreshes app using
  `Browser.Navigation.reloadAndSkipCache`